### PR TITLE
nodejs 14.15.x uses "undefined" when checking Module cache

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -400,7 +400,7 @@ function readFile(path) {
 }
 
 function requireJS(path, opts) {
-  require.cache[path] = null;
+  require.cache[path] = undefined;
   var data = require(path);
   if (typeof data === 'function' && data.length > 0) {
     return data(opts);

--- a/src/index.es
+++ b/src/index.es
@@ -356,7 +356,7 @@ function readFile(path, filter = () => true, opts) {
 
 
 function requireJS(path, opts) {
-  require.cache[path] = null
+  require.cache[path] = undefined;
   const data = require(path)
   if (typeof data === 'function' && data.length > 0) {
     return data(opts)


### PR DESCRIPTION
Setting Module cache to "null" no longer indicate the module has
not been loaded, mustache-cli then fails with following message:
TypeError: Cannot read property 'loaded' of null
    at Function.Module._load (internal/modules/cjs/loader.js:730:23)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at requireJS (/home/chunlinl/www/v5/mustache-cli/lib/index.js:404:14)
    at readFile (/home/chunlinl/www/v5/mustache-cli/lib/index.js:392:17)
    at /home/chunlinl/www/v5/mustache-cli/lib/index.js:386:31
    at Array.forEach (<anonymous>)
    at readFile (/home/chunlinl/www/v5/mustache-cli/lib/index.js:385:10)
    at readData (/home/chunlinl/www/v5/mustache-cli/lib/index.js:186:15)
    at output (/home/chunlinl/www/v5/mustache-cli/lib/index.js:163:3)